### PR TITLE
Direct g++ to treat the code as modern C++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ YAC_OUT         ?= $(BUILD_DIR)/VCDParser.cpp
 YAC_HEADER      ?= $(BUILD_DIR)/VCDParser.hpp
 YAC_OBJ         ?= $(BUILD_DIR)/VCDParser.o
 
-CXXFLAGS        += -I$(BUILD_DIR) -I$(SRC_DIR) -g
+CXXFLAGS        += -I$(BUILD_DIR) -I$(SRC_DIR) -g -std=c++0x
 
 VCD_SRC         ?= $(SRC_DIR)/VCDFile.cpp \
                    $(SRC_DIR)/VCDValue.cpp \


### PR DESCRIPTION
This is needed on newer version of g++ as it throws an error during compilation if I don't include this flag.

The error I get is:

```
./src/VCDParser.ypp: In member function ‘virtual int VCDParser::parser::parse()’:
./src/VCDParser.ypp:259:5: error: ‘scanf’ is not a member of ‘std’
     std::scanf(buffer, "%g", &real_value);
```