### PR TITLE
Fix O(n^2) performance problem

### DIFF
--- a/src/VCDFile.cpp
+++ b/src/VCDFile.cpp
@@ -124,15 +124,16 @@ void VCDFile::add_timestamp(
 /*!
 */
 VCDValue * VCDFile::get_signal_value_at (
-    VCDSignalHash hash,
+    const VCDSignalHash& hash,
     VCDTime       time,
     bool erase_prior
 ){
-    if(this -> val_map.find(hash) == this -> val_map.end()) {
+    auto find = val_map.find(hash); 
+    if(find == this -> val_map.end()) {
         return nullptr;
     }
     
-    VCDSignalValues * vals = this -> val_map[hash];
+    VCDSignalValues * vals = find->second;
 
     if(vals -> size() == 0) {
         return nullptr;

--- a/src/VCDFile.hpp
+++ b/src/VCDFile.hpp
@@ -92,12 +92,14 @@ class VCDFile {
         vector returned by get_timestamps().
         @param hash in - The hashcode for the signal to identify it.
         @param time in - The time at which we want the value of the signal.
+        @param erase_prior in - Erase signals prior to this time. Avoids O(n^2) searching times when scanning large .vcd files sequentially.
         @returns A pointer to the value at the supplie time, or nullptr if
         no such record can be found.
         */
         VCDValue * get_signal_value_at (
             VCDSignalHash hash,
-            VCDTime       time
+            VCDTime       time,
+            bool erase_prior = false
         );
 
         

--- a/src/VCDFile.hpp
+++ b/src/VCDFile.hpp
@@ -97,7 +97,7 @@ class VCDFile {
         no such record can be found.
         */
         VCDValue * get_signal_value_at (
-            VCDSignalHash hash,
+            const VCDSignalHash& hash,
             VCDTime       time,
             bool erase_prior = false
         );

--- a/src/VCDTypes.hpp
+++ b/src/VCDTypes.hpp
@@ -3,6 +3,7 @@
 #include <utility>
 #include <string>
 #include <vector>
+#include <deque>
 
 /*!
 @file VCDTypes.hpp
@@ -66,7 +67,7 @@ typedef struct {
 
 
 //! A vector of tagged time/value pairs, sorted by time values.
-typedef std::vector<VCDTimedValue*> VCDSignalValues;
+typedef std::deque<VCDTimedValue*> VCDSignalValues;
 
 
 //! Variable types of a signal in a VCD file.


### PR DESCRIPTION
get_signal_value_at() has a performance degradation of O(n^2).

This introduces a simple fix where history is deleted as the .vcd file is scanned sequentially.