### PR TITLE
Fix build with newer gcc

### DIFF
--- a/src/VCDFileParser.hpp
+++ b/src/VCDFileParser.hpp
@@ -10,6 +10,7 @@
 #include <map>
 #include <set>
 #include <stack>
+#include <limits>
 
 #include "VCDParser.hpp"
 #include "VCDTypes.hpp"


### PR DESCRIPTION
I'm hitting a build error with gcc 10:

src/VCDFileParser.cpp:12:32: error: ‘numeric_limits’ is not a member of ‘std’