### PR TITLE
Fix parsing 1-bit vector

### DIFF
--- a/src/VCDParser.ypp
+++ b/src/VCDParser.ypp
@@ -291,8 +291,13 @@ reference:
     TOK_BRACKET_C{
     $$  = new VCDSignal();
     $$ -> reference = $1;
-    $$ -> lindex = $3;
-    $$ -> rindex = $5;
+    if ($3 == 0 && $3 == $5) {
+        $$ -> lindex = -1;
+        $$ -> rindex = -1;
+    } else {
+        $$ -> lindex = $3;
+        $$ -> rindex = $5;
+    }
 }
 
 comment_text :


### PR DESCRIPTION
The reference of a vector variable can have a size of 1, but still declared as an array, e.g., "$var wire 1 %, x [0:0] $end". With the original implementation, an assertion will be triggered because vectors are supposed to have a size larger than 1.